### PR TITLE
feat: add carrier management crud

### DIFF
--- a/app/Http/Controllers/CarrierController.php
+++ b/app/Http/Controllers/CarrierController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Carrier;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class CarrierController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): Response
+    {
+        return Inertia::render('Carriers/Index', [
+            'carriers' => Carrier::all(),
+        ]);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'company_name' => ['required', 'string', 'max:255'],
+            'contact_person' => ['nullable', 'string', 'max:255'],
+            'phone_number' => ['nullable', 'string', 'max:50'],
+            'email' => ['nullable', 'email', 'max:255'],
+            'cost_details' => ['nullable', 'string'],
+        ]);
+
+        Carrier::create($data);
+
+        return redirect()->route('carriers.index');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Carrier $carrier): RedirectResponse
+    {
+        $data = $request->validate([
+            'company_name' => ['required', 'string', 'max:255'],
+            'contact_person' => ['nullable', 'string', 'max:255'],
+            'phone_number' => ['nullable', 'string', 'max:50'],
+            'email' => ['nullable', 'email', 'max:255'],
+            'cost_details' => ['nullable', 'string'],
+        ]);
+
+        $carrier->update($data);
+
+        return redirect()->route('carriers.index');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Carrier $carrier): RedirectResponse
+    {
+        $carrier->delete();
+
+        return redirect()->route('carriers.index');
+    }
+}

--- a/app/Http/Middleware/EnsureUserIsManager.php
+++ b/app/Http/Middleware/EnsureUserIsManager.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserIsManager
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($request->user()?->role !== 'Manager') {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Carrier.php
+++ b/app/Models/Carrier.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Carrier extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'company_name',
+        'contact_person',
+        'phone_number',
+        'email',
+        'cost_details',
+    ];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,6 +23,7 @@ class User extends Authenticatable
         'password',
         'telegram_id',
         'username',
+        'role',
     ];
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -14,6 +14,10 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->web(append: [
             \App\Http\Middleware\HandleInertiaRequests::class,
         ]);
+
+        $middleware->alias([
+            'manager' => \App\Http\Middleware\EnsureUserIsManager::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/database/factories/CarrierFactory.php
+++ b/database/factories/CarrierFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Carrier;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Carrier>
+ */
+class CarrierFactory extends Factory
+{
+    protected $model = Carrier::class;
+
+    public function definition(): array
+    {
+        return [
+            'company_name' => $this->faker->company(),
+            'contact_person' => $this->faker->name(),
+            'phone_number' => $this->faker->phoneNumber(),
+            'email' => $this->faker->safeEmail(),
+            'cost_details' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,6 +29,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'role' => 'User',
         ];
     }
 

--- a/database/migrations/2025_09_03_000000_create_carriers_table.php
+++ b/database/migrations/2025_09_03_000000_create_carriers_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('carriers', function (Blueprint $table) {
+            $table->id();
+            $table->string('company_name');
+            $table->string('contact_person')->nullable();
+            $table->string('phone_number')->nullable();
+            $table->string('email')->nullable();
+            $table->text('cost_details')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('carriers');
+    }
+};

--- a/database/migrations/2025_09_03_000001_add_role_to_users_table.php
+++ b/database/migrations/2025_09_03_000001_add_role_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('role')->default('User')->after('username');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/database/seeders/CarrierSeeder.php
+++ b/database/seeders/CarrierSeeder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Carrier;
+use Illuminate\Database\Seeder;
+
+class CarrierSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Carrier::factory()->count(3)->create();
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Database\Seeders\CarrierSeeder;
 
 class DatabaseSeeder extends Seeder
 {
@@ -19,5 +20,7 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        $this->call(CarrierSeeder::class);
     }
 }

--- a/resources/js/Components/Carriers/Form.test.js
+++ b/resources/js/Components/Carriers/Form.test.js
@@ -1,0 +1,25 @@
+import { vi, expect, test } from 'vitest';
+
+vi.mock('@inertiajs/vue3', () => ({
+  router: {
+    post: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+import { mount } from '@vue/test-utils';
+import Form from './Form.vue';
+import { router } from '@inertiajs/vue3';
+
+test('shows validation error when company name missing', async () => {
+  const wrapper = mount(Form);
+  await wrapper.find('form').trigger('submit.prevent');
+  expect(wrapper.text()).toContain('Company name is required');
+});
+
+test('submits form data', async () => {
+  const wrapper = mount(Form);
+  await wrapper.find('input[name="company_name"]').setValue('Acme');
+  await wrapper.find('form').trigger('submit.prevent');
+  expect(router.post).toHaveBeenCalledWith('/carriers', expect.objectContaining({ company_name: 'Acme' }));
+});

--- a/resources/js/Components/Carriers/Form.vue
+++ b/resources/js/Components/Carriers/Form.vue
@@ -1,0 +1,60 @@
+<template>
+  <form @submit.prevent="submit" class="space-y-4">
+    <div>
+      <label class="block">Company Name</label>
+      <input name="company_name" v-model="form.company_name" class="border" />
+      <div v-if="form.errors.company_name" class="text-red-500">{{ form.errors.company_name }}</div>
+    </div>
+    <div>
+      <label class="block">Contact Person</label>
+      <input name="contact_person" v-model="form.contact_person" class="border" />
+    </div>
+    <div>
+      <label class="block">Phone Number</label>
+      <input name="phone_number" v-model="form.phone_number" class="border" />
+    </div>
+    <div>
+      <label class="block">Email</label>
+      <input name="email" v-model="form.email" class="border" />
+    </div>
+    <div>
+      <label class="block">Cost Details</label>
+      <textarea name="cost_details" v-model="form.cost_details" class="border" />
+    </div>
+    <button type="submit" class="bg-blue-500 text-white px-4 py-2">
+      {{ props.carrier ? 'Update' : 'Create' }}
+    </button>
+  </form>
+</template>
+
+<script setup>
+import { reactive } from 'vue';
+import { router } from '@inertiajs/vue3';
+
+const props = defineProps({
+  carrier: { type: Object, default: null },
+});
+
+const form = reactive({
+  company_name: props.carrier?.company_name || '',
+  contact_person: props.carrier?.contact_person || '',
+  phone_number: props.carrier?.phone_number || '',
+  email: props.carrier?.email || '',
+  cost_details: props.carrier?.cost_details || '',
+  errors: {},
+});
+
+function submit() {
+  form.errors = {};
+  if (!form.company_name) {
+    form.errors.company_name = 'Company name is required';
+    return;
+  }
+
+  if (props.carrier) {
+    router.put(`/carriers/${props.carrier.id}`, form);
+  } else {
+    router.post('/carriers', form);
+  }
+}
+</script>

--- a/resources/js/Pages/Carriers/Index.test.js
+++ b/resources/js/Pages/Carriers/Index.test.js
@@ -1,0 +1,21 @@
+import { mount } from '@vue/test-utils';
+import { expect, test, vi } from 'vitest';
+import Index from './Index.vue';
+
+vi.mock('@inertiajs/vue3', () => ({
+  Head: { template: '<div><slot /></div>' },
+  router: { delete: vi.fn() },
+}));
+
+test('lists carriers', () => {
+  const carriers = [
+    { id: 1, company_name: 'Carrier A', contact_person: 'Alice' },
+    { id: 2, company_name: 'Carrier B', contact_person: 'Bob' },
+  ];
+  const wrapper = mount(Index, {
+    props: { carriers },
+    global: { stubs: { Form: { template: '<div></div>' } } },
+  });
+  expect(wrapper.text()).toContain('Carrier A');
+  expect(wrapper.text()).toContain('Carrier B');
+});

--- a/resources/js/Pages/Carriers/Index.vue
+++ b/resources/js/Pages/Carriers/Index.vue
@@ -1,0 +1,46 @@
+<template>
+  <Head title="Carriers" />
+  <div class="p-4">
+    <h1 class="text-2xl mb-4">Carriers</h1>
+    <Form :carrier="editingCarrier" />
+    <table class="mt-4 w-full" v-if="carriers.length">
+      <thead>
+        <tr>
+          <th class="text-left">Company</th>
+          <th class="text-left">Contact</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="carrier in carriers" :key="carrier.id" class="border-t">
+          <td>{{ carrier.company_name }}</td>
+          <td>{{ carrier.contact_person }}</td>
+          <td class="space-x-2">
+            <button class="text-blue-500" @click="editCarrier(carrier)">Edit</button>
+            <button class="text-red-500" @click="deleteCarrier(carrier)">Delete</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup>
+import { Head, router } from '@inertiajs/vue3';
+import { ref } from 'vue';
+import Form from '../../Components/Carriers/Form.vue';
+
+const props = defineProps({
+  carriers: { type: Array, default: () => [] },
+});
+
+const editingCarrier = ref(null);
+
+function editCarrier(carrier) {
+  editingCarrier.value = carrier;
+}
+
+function deleteCarrier(carrier) {
+  router.delete(`/carriers/${carrier.id}`);
+}
+</script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Auth\TelegramLoginController;
+use App\Http\Controllers\CarrierController;
 use Inertia\Inertia;
 
 Route::get('/', function () {
@@ -15,4 +16,13 @@ Route::middleware('auth')->group(function () {
     Route::get('/dashboard', function () {
         return Inertia::render('Dashboard');
     })->name('dashboard');
+});
+
+Route::middleware(['auth', 'manager'])->group(function () {
+    Route::resource('carriers', CarrierController::class)->only([
+        'index',
+        'store',
+        'update',
+        'destroy',
+    ]);
 });

--- a/tests/Feature/CarrierManagementTest.php
+++ b/tests/Feature/CarrierManagementTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Carrier;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CarrierManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function manager(): User
+    {
+        return User::factory()->create(['role' => 'Manager']);
+    }
+
+    public function test_only_manager_can_access_carriers_index(): void
+    {
+        $manager = $this->manager();
+        $response = $this->actingAs($manager)->get('/carriers');
+        $response->assertStatus(200);
+
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->get('/carriers');
+        $response->assertStatus(403);
+    }
+
+    public function test_manager_can_create_carrier(): void
+    {
+        $manager = $this->manager();
+        $response = $this->actingAs($manager)->post('/carriers', [
+            'company_name' => 'Acme Logistics',
+            'contact_person' => 'John Doe',
+            'phone_number' => '123456789',
+            'email' => 'carrier@example.com',
+            'cost_details' => 'Details',
+        ]);
+        $response->assertRedirect('/carriers');
+        $this->assertDatabaseHas('carriers', ['company_name' => 'Acme Logistics']);
+    }
+
+    public function test_manager_can_update_carrier(): void
+    {
+        $manager = $this->manager();
+        $carrier = Carrier::create(['company_name' => 'Old', 'contact_person' => null]);
+        $response = $this->actingAs($manager)->put("/carriers/{$carrier->id}", [
+            'company_name' => 'New Name',
+        ]);
+        $response->assertRedirect('/carriers');
+        $this->assertDatabaseHas('carriers', ['id' => $carrier->id, 'company_name' => 'New Name']);
+    }
+
+    public function test_manager_can_delete_carrier(): void
+    {
+        $manager = $this->manager();
+        $carrier = Carrier::create(['company_name' => 'Temp', 'contact_person' => null]);
+        $response = $this->actingAs($manager)->delete("/carriers/{$carrier->id}");
+        $response->assertRedirect('/carriers');
+        $this->assertDatabaseMissing('carriers', ['id' => $carrier->id]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,9 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutVite();
+    }
 }


### PR DESCRIPTION
## Summary
- implement carrier CRUD with manager-only access
- add carrier form and list pages in Vue
- seed sample carriers and add tests

## Testing
- `php artisan test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b6f73882f0832e8f8a36c3a0336d42